### PR TITLE
feat(workloads): add paperless-ngx

### DIFF
--- a/kubernetes/argocd/apps/infrastructure/postgres/manifests/cluster.yaml
+++ b/kubernetes/argocd/apps/infrastructure/postgres/manifests/cluster.yaml
@@ -48,3 +48,8 @@ spec:
         createdb: true
         passwordSecret:
           name: tidewood-db-user
+      - name: paperless
+        ensure: present
+        login: true
+        passwordSecret:
+          name: paperless-db-user

--- a/kubernetes/argocd/apps/infrastructure/postgres/manifests/kustomization.yaml
+++ b/kubernetes/argocd/apps/infrastructure/postgres/manifests/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
   - immich-database.yaml
   - tidewood-db-user-secret.sops.yaml
   - tidewood-database.yaml
+  - paperless-db-user-secret.sops.yaml
+  - paperless-database.yaml

--- a/kubernetes/argocd/apps/infrastructure/postgres/manifests/paperless-database.yaml
+++ b/kubernetes/argocd/apps/infrastructure/postgres/manifests/paperless-database.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: paperless
+  namespace: postgres
+spec:
+  cluster:
+    name: postgres-homelab
+  name: paperless
+  owner: paperless

--- a/kubernetes/argocd/apps/infrastructure/postgres/manifests/paperless-db-user-secret.sops.yaml
+++ b/kubernetes/argocd/apps/infrastructure/postgres/manifests/paperless-db-user-secret.sops.yaml
@@ -1,0 +1,81 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: paperless-db-user
+    namespace: postgres
+spec:
+    secretTemplates:
+        - name: paperless-db-user
+          type: kubernetes.io/basic-auth
+          stringData:
+            username: ENC[AES256_GCM,data:lPfmFRkPVN1V,iv:ekdXpjuC1f9Z2izjnah+0F9PUuAJ2Mz2ip+3poFhzao=,tag:gvMNjWXhrJ3k0t8+v53YLg==,type:str]
+            password: ENC[AES256_GCM,data:rsGLtWPeovCzluoimMzmhp0Hl6LF1TeNbHp/yJvmQws=,iv:0hiTELijldheFanGJaiExgQavku3Illw1U4/hGI/AH4=,tag:I4AEGa/tx6fUF3IgtODwYw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMZzFEL2NJMFdsbW5iclZZ
+            QmFXenNYeUg2V3pIVTA0aGYzT0EwNi95UHlNCkJNS0FJZ3ltMzg5RVV2VWJzcStI
+            ZHM0YXNPRzBETUtDSE1tVWp0c1BmWncKLS0tIEoyNTZuRzNYL1Y0ZHV5eWozdFJ1
+            a1pudkNKRnc5N0dicFJSOFRZaFk4NGcK7UOCWsc8tlg93wPvUlHY+X+8ObzqV8Q7
+            EdnuHSRl/ACzWf3FUtAEBtTUxetyr1+r8CAeYPVaCNPjiAVjcFp9bA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age16vnesw9pd7l556h9lmgv4lyya03xsu2akc5hukhgua8mffukmsms46665n
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvRWsyUi9TdERLaW9xWGhm
+            WEtqK0dpVWk3bkFYUlZLYk01YWxJdWJIU1UwCmxDWFcyeGo5REpycU51UmNtUG0r
+            UjNCRGF5ZkRZOUZaL2tvbE9ncENoVlkKLS0tIGFsbUVHMU5uc3BXTFRtOHBMdFNP
+            QURiS1kxS1cvYXZCMjNVRFpLTWRXczgKhwuzjGCeH8W+GPHUo/2WywqDTpyIawe9
+            vVBmssALJgkacgXU5z4sTtkXdnA4uUUJRU0UXYnM68gUftkChLMiaQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1cxqfxy46kp8p007857c6cnk4j2ypuc0pw04utqr58uraxn0dz3ystslpxj
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2QXVQWjdxMmZGbm5RQWNh
+            UHE1M2FiL2lIeWFNanhaZ0dxeTdtKzk1cVNBCkFiUFp0dlZQdlhkU3dSaWI3S1pK
+            bVZZNHV5OXk3cjk2S1dPRDd4L1NHRDQKLS0tIEd3UzZmUVhFZWNSV2RZNnIzMElB
+            bldQRDNTU0xTVzBJb3ZseWV4RnMrQnMKjOob1+ZZuGMjrZqF1mImopti1y0Hd/3p
+            qnfnmMMic4Sd3dJ1Zs7xgWfgvY8Eg7+tN3ELjknm1C/3XlrypcXQ8Q==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ye3vjfjzfpdd9eqn9qlhj0jr369h8xgdxlj0j0yplpg2xqsfna3qrm73gl
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZNEFOTUZETVJkNXpLUHF4
+            eFAyNkliVkUwOHN3aCtGRDFvREdXV0pzTlFNClRZK2Z5d1RGN2hCenhZVVdzL0RT
+            UlM5SHB5UWhrbE5iUy9uamVyVExNeTQKLS0tIFovUG5lNHExSzg3c0hGU1Q1NWNq
+            Y1R1NW9YMWZSVUJGYUd5R1cyYURzOEEKqBai33Yq8k9JcY0bObIGZnbmbTvmPcEB
+            HfJotwANs6G+3WhmFGnF5RK50FN9OBKGBaOJSQyWjhbH0w89fhcpkg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age10kuyqqdzgtefr40redrl6xnw9a3pcl2589dw63n5qlllnscxccrq8jez7f
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLbzQxY1VBK2hRWDh3MVE5
+            NEpHUzRYM3VMeGk1ZW5TLzIvYVNtdTlnMG1ZCjJuYVhJeDZYTlBCS0UyR2t6eldQ
+            VktVeisyM3crdFhjQkZRd0I0a0hVYVkKLS0tIHNJcGMxWjIzZDdoUDltY2JiWG5U
+            a09MSFdpVmtFeGFrcUZvbWI5M2M3SUUKnqKu72csyeLRWI2Nv2PX5TzMoV5hoT90
+            7UsPW99wQZjtg5ut2FvnMavJAaB29arv+JcFr5Q8lNiGRyq3CM0XHQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1cll0t2zmt8xj5x9zuka8zknymzqd5l4ewcv79yrwe9szd06kacyq5wfwr4
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVSzlFTVdPcmxlUUx5eEkx
+            RmFQbENYbXI3RnpwZ08rZDFxVEZKREZrTzAwCjFlVkNrSXdjdmx1OEdhT0tCL2lD
+            bERKbisxVkVvYzV4SGdrdk93c2xPRW8KLS0tIHNPdGU3QnplUXY5L3BScEYyVGFm
+            VXRsT083R2laRU1xTzRLbHdGYWcvM0EKHujD0wuXOVNGM70fjOOrR8fPV0YXZOzW
+            LuS4Ywg4mQF+JU97l6kQCCyoJon42YohOdaZ+N07xQ47hKFJ5j8D/A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1g93uv85j5x5l9twvg4833736vcyrca2femh7gkytq8dtnhkzgs9qyfynf0
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxOVBveEVvZUI1dWszREs5
+            dXdZdm1meVRuWlNIdXJVVWIzMXptR1Vua3lrCnFDTUhaQlp4TG9LeGI4Y2x2TGY3
+            TnhFc25nZ3lsQmNzL0s4a3lYL1NnRVUKLS0tIEdEWWhYTE1taHdhTzVOcUozSU0v
+            S2hYREV0aVhtMUNuTzBOaFZCdEdIYXcKMhpFIHF54x1o9qU1JhypMe7B0Q5Rpd2Y
+            95Rfq5DLQBZVG7H/Cn5vtYx+8yS5majCCUbzgHoDqjyRngw6J/JL4Q==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age17mzyvmc2dr266c5ky90e8earmvy39awwskhk6nwfavn8vprq3gwqzhcc3e
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-31T21:22:22Z"
+    mac: ENC[AES256_GCM,data:sKl7bhBjS3bideTBgDRup4VDXMBM54Loq5TRP+s6ZXHK9IjsQPLVjknVgeJpVKAvYtUMg30hsun2XRn1by7XBw1p5QfeggWfkWR7efiz4U1uKIG8Esh7oIcHVbEIxEJtRf9SuwGpk6BtySS2HMMSWeY4/L776OsJLcg9UWBt0ow=,iv:8mlbItkYPPoLfn8Ax/ywwpKJE+l5KJ1XzMRgBf5mrR0=,tag:I1zLwikKvtd5D5NlVl4ymw==,type:str]
+    version: 3.13.3

--- a/kubernetes/argocd/apps/workloads/paperless/application.yaml
+++ b/kubernetes/argocd/apps/workloads/paperless/application.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: paperless
+  namespace: argocd
+  annotations:
+    # Wave 3: the postgres `paperless` role + Database land in wave 1.
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/paulkiernan/homelab
+    targetRevision: HEAD
+    path: kubernetes/argocd/apps/workloads/paperless/manifests
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: paperless
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/kubernetes/argocd/apps/workloads/paperless/manifests/broker.yaml
+++ b/kubernetes/argocd/apps/workloads/paperless/manifests/broker.yaml
@@ -1,0 +1,92 @@
+---
+# Celery broker. Paperless needs something that speaks the Redis protocol for
+# its task queue (consumption, OCR, scheduled jobs). Valkey is what upstream
+# ships in their compose files.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-broker
+  namespace: paperless
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: nas-nfs
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paperless-broker
+  namespace: paperless
+  labels:
+    app: paperless
+    component: broker
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: paperless
+      component: broker
+  template:
+    metadata:
+      labels:
+        app: paperless
+        component: broker
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: valkey
+          image: docker.io/valkey/valkey:9-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6379
+              name: redis
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command: ["valkey-cli", "ping"]
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          readinessProbe:
+            exec:
+              command: ["valkey-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 25m
+            limits:
+              memory: 256Mi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: paperless-broker
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: paperless-broker
+  namespace: paperless
+  labels:
+    app: paperless
+    component: broker
+spec:
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis
+      protocol: TCP
+  selector:
+    app: paperless
+    component: broker

--- a/kubernetes/argocd/apps/workloads/paperless/manifests/deployment.yaml
+++ b/kubernetes/argocd/apps/workloads/paperless/manifests/deployment.yaml
@@ -1,0 +1,179 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paperless
+  namespace: paperless
+  labels:
+    app: paperless
+    component: server
+spec:
+  replicas: 1
+  # Recreate, not RollingUpdate: the media and data volumes are RWX, so a
+  # rolling update would briefly run two pods writing the same tantivy search
+  # index. One writer at a time only.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: paperless
+      component: server
+  template:
+    metadata:
+      labels:
+        app: paperless
+        component: server
+    spec:
+      # No securityContext/runAsUser here on purpose. The upstream image uses
+      # s6-overlay (ENTRYPOINT ["/init"]) and starts as root so it can map
+      # ownership of the mounted volumes before dropping to uid 1000.
+      containers:
+        - name: paperless
+          image: ghcr.io/paperless-ngx/paperless-ngx:3.0.4
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000
+              name: http
+              protocol: TCP
+          env:
+            # --- Database (CloudNativePG cluster in the postgres namespace) ---
+            - name: PAPERLESS_DBENGINE
+              value: postgresql
+            - name: PAPERLESS_DBHOST
+              value: postgres-homelab-rw.postgres.svc.cluster.local
+            - name: PAPERLESS_DBPORT
+              value: "5432"
+            - name: PAPERLESS_DBNAME
+              value: paperless
+            - name: PAPERLESS_DBUSER
+              value: paperless
+            - name: PAPERLESS_DBPASS
+              valueFrom:
+                secretKeyRef:
+                  name: paperless-secrets
+                  key: PAPERLESS_DBPASS
+
+            # --- Celery broker ---
+            - name: PAPERLESS_REDIS
+              value: redis://paperless-broker:6379
+
+            # --- Hosting ---
+            # Required as of v3: paperless refuses to start without it.
+            - name: PAPERLESS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: paperless-secrets
+                  key: PAPERLESS_SECRET_KEY
+            # Sets ALLOWED_HOSTS, CORS_ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS.
+            - name: PAPERLESS_URL
+              value: https://paperless.border-enigmatic.ts.net
+            - name: PAPERLESS_TIME_ZONE
+              value: America/Los_Angeles
+
+            # --- Bootstrap superuser ---
+            # Only creates the user if it does not already exist; it never
+            # rewrites the password, so this is safe to leave set forever.
+            - name: PAPERLESS_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: paperless-secrets
+                  key: PAPERLESS_ADMIN_USER
+            - name: PAPERLESS_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: paperless-secrets
+                  key: PAPERLESS_ADMIN_PASSWORD
+            - name: PAPERLESS_ADMIN_MAIL
+              value: paulkiernan1@gmail.com
+
+            # --- Consumer ---
+            # The consume dir is NFS, where inotify is unreliable, so poll it
+            # instead. STABILITY_DELAY guards against picking up a file that
+            # the NAS is still flushing.
+            - name: PAPERLESS_CONSUMER_POLLING_INTERVAL
+              value: "30"
+            - name: PAPERLESS_CONSUMER_STABILITY_DELAY
+              value: "10"
+            - name: PAPERLESS_CONSUMER_RECURSIVE
+              value: "true"
+            - name: PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS
+              value: "true"
+
+            # --- OCR / workers ---
+            - name: PAPERLESS_OCR_LANGUAGE
+              value: eng
+            # TASK_WORKERS * THREADS_PER_WORKER must stay <= the node's CPU
+            # count; every node in this cluster has 4.
+            - name: PAPERLESS_TASK_WORKERS
+              value: "2"
+            - name: PAPERLESS_THREADS_PER_WORKER
+              value: "2"
+            - name: PAPERLESS_WEBSERVER_WORKERS
+              value: "2"
+
+            # --- Paths (container-internal; match the volumeMounts below) ---
+            - name: PAPERLESS_DATA_DIR
+              value: /usr/src/paperless/data
+            - name: PAPERLESS_MEDIA_ROOT
+              value: /usr/src/paperless/media
+            - name: PAPERLESS_CONSUMPTION_DIR
+              value: /usr/src/paperless/consume
+            # Deleted documents move here instead of being unlinked, so an
+            # accidental delete is recoverable off the NAS.
+            - name: PAPERLESS_EMPTY_TRASH_DIR
+              value: /usr/src/paperless/media/trash
+
+          volumeMounts:
+            - name: data
+              mountPath: /usr/src/paperless/data
+            - name: media
+              mountPath: /usr/src/paperless/media
+            - name: consume
+              mountPath: /usr/src/paperless/consume
+            - name: export
+              mountPath: /usr/src/paperless/export
+
+          # First boot runs migrations against an empty database and builds the
+          # search index, which takes a while — hence the generous startupProbe
+          # budget (30 * 20s = 10 min) before liveness takes over.
+          startupProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 20
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 3
+
+          resources:
+            requests:
+              memory: 1Gi
+              cpu: 500m
+            limits:
+              memory: 4Gi
+
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: paperless-data
+        - name: media
+          persistentVolumeClaim:
+            claimName: paperless-media
+        - name: consume
+          persistentVolumeClaim:
+            claimName: paperless-consume
+        - name: export
+          persistentVolumeClaim:
+            claimName: paperless-export

--- a/kubernetes/argocd/apps/workloads/paperless/manifests/kustomization.yaml
+++ b/kubernetes/argocd/apps/workloads/paperless/manifests/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - broker.yaml
+  - deployment.yaml
+  - service.yaml
+  - tailscale-ingress.yaml
+  - paperless-secrets.sops.yaml

--- a/kubernetes/argocd/apps/workloads/paperless/manifests/namespace.yaml
+++ b/kubernetes/argocd/apps/workloads/paperless/manifests/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: paperless

--- a/kubernetes/argocd/apps/workloads/paperless/manifests/paperless-secrets.sops.yaml
+++ b/kubernetes/argocd/apps/workloads/paperless/manifests/paperless-secrets.sops.yaml
@@ -1,0 +1,84 @@
+apiVersion: isindir.github.com/v1alpha3
+kind: SopsSecret
+metadata:
+    name: paperless-secrets
+    namespace: paperless
+spec:
+    secretTemplates:
+        - name: paperless-secrets
+          stringData:
+            #ENC[AES256_GCM,data:r4ADlgx4cFRfIA6IBLySV8IMZ8CEndgCBxQaEvrSYHIAuJ00grfaYu/tDj1qpZNVgmjz,iv:yJCuCtHGhShcsM4zBzzM8ceiP6ZhXGtDdTiXHHut/fg=,tag:8lnAUdW0OR2AU246xJ2xhQ==,type:comment]
+            #ENC[AES256_GCM,data:ewmzNN8VWUq12X4uavMgiBniuwIUfCUBduMbpe1YYXeDmfvnu50wS4rkNsTRGy52gX0Nd4wucGEb0LdyK1D4LU+yKRkNe36CmPQO19Kj34cb5Jaa/bTC0gusj7k=,iv:FawhYIBNM6DhLjQuMpG89W47A4wchH1Qp/6VgOO5N3k=,tag:WXEIk+L3hxaVodvbi8JFKg==,type:comment]
+            PAPERLESS_DBPASS: ENC[AES256_GCM,data:XDXmsf5yAarTDnxdX6mscGzIb2ZTNGM4fOnFR0bJnu8=,iv:Jsl39BI+8P7yeXedSGFuAxYly5Wh76LahMijOwnAv4c=,tag:sci7Q89+vtp2rks+QmIBmg==,type:str]
+            PAPERLESS_SECRET_KEY: ENC[AES256_GCM,data:fNLCqn6zb+lAVdjzz1CyFed0WabV1tLQdp/5wJGbI21GmJitaiG82aFIUFjVKom8p+3IMdd+OBj77G4H3rSs76YTDqePO0i/UV1Vd3efqQWB7k1VrGg=,iv:5lVoK+dZ2jlhAabT4DU0pK7ExE9GwAmuhSJz8lSlknY=,tag:JojMtgIoeWpDsJbZCx16kg==,type:str]
+            PAPERLESS_ADMIN_USER: ENC[AES256_GCM,data:vdSyqg==,iv:CdiLkjrTbPVXqXlufHEhJxiNl9TM4LaII3JJZqQQlw0=,tag:s0lRs2GTFIUzZGYtLv2A2g==,type:str]
+            PAPERLESS_ADMIN_PASSWORD: ENC[AES256_GCM,data:SLPnury/t4jVhvigl7mZ6sr6Iy8xvo9Z,iv:gVP+APqSLm0D2JckfrsiM1uc4HQs24vMAZandoC3xyg=,tag:nhI51m630tJK3LUZw3lEDQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQaWtmYUVOZUN5MUlvUS9W
+            eFgyUE9UQW9KZ3RxOXRmRzdPaU1tYjFaa0ZzCnRWbFJGSmxQT2ljMDNBczVzSkpm
+            VjhJUzlDTUI0UWZEQWFZa2Z2d1A0bVUKLS0tIHZUaHlrb09nUjE2bTVvamc3YTF5
+            RFhwY3kyUmZGbWRaM3J4YjlZR0VJdVEKC/4Nk5L4lo13LLIJcBUx/G+7yQg/8Hr7
+            KXcqySLFpJzEmJakD/qeCaSFwKzdWUll6m2w7aA/LiVJu9kAcW48ew==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age16vnesw9pd7l556h9lmgv4lyya03xsu2akc5hukhgua8mffukmsms46665n
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzSERqc29CR0tNRFJScUtu
+            OVovaW8yeFUwQU0zU1pCV2pmazRNMnEwZlNrClVFUmVyRUlyM0xDTlFMemtMTytr
+            VGw0REtUNC9yVFFoTXlORCtGRFNSUE0KLS0tIFQzaS96NEpKS1FhOVFLaTc2VTUr
+            ZG5uT1JUYWZXRjVaQkZpUklFZERob1kKCr0T25zfVGyijr6K1KPTjmAsiysPNn7T
+            bc+JAjDdiqdp9DC6od4wGJ+9Fq95UG+7An9z0NasCSb739Gub65OTg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1cxqfxy46kp8p007857c6cnk4j2ypuc0pw04utqr58uraxn0dz3ystslpxj
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuT0Q4N1FudG55RmhsR3VN
+            SFlaTFNtbklUd2lYK1ZqYXFiRmt3ZWxDb0dvCjNJNjQyZzZGT3d6U0djTE83ZnpX
+            aER2cnd3eGtBK1ArRUZGb1g1RVk0bVEKLS0tIEVQZ01kWHlabGtpZE0yV3VGQ3hj
+            R1NTR3R2OUZDbUVDdkQrVExGQWtMMjQKbumvaMkC7jJkH0ijHDREUi6dwfur9BvW
+            f0RhI7ahyveonkyRfJYEjxYbV9VOikD1UYGqNxvHjNbxYceJJguNPA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ye3vjfjzfpdd9eqn9qlhj0jr369h8xgdxlj0j0yplpg2xqsfna3qrm73gl
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhT2NvZXFXdThCWkhQWVBz
+            ZXU2YU1FYUFtaDFnbnBCd3d6ZzdIOG96Y0FvCkZyRk9kb0hlOEU2QWxjU0JZT3Z2
+            STVPZUNBcGRwU2c3ODVodm5Jb001V2sKLS0tIGNIWFNyKzlBZWhPd1hWSDQrUmMx
+            MVBBUk9lZ1RHQmVqdUhYMEtvQnN2QW8K05h7rCUs2V1ZE0CLnwC4yvuZOItu3mBW
+            IkPk5LFCX9kdPl/w/wnTpOUe6ZHpBaQhhQW79sBkOeVqntNIR9xuMg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age10kuyqqdzgtefr40redrl6xnw9a3pcl2589dw63n5qlllnscxccrq8jez7f
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwRTZ6SUpMYlRUVmQxbzdH
+            cTdlMkNtSWJiT01LOHhCdFBSaWZoOTI3Mm13Cmd2bndaeGVYdlVRT2lGeWY3czNT
+            SkgybzdlM1hKREhoMjIxc0xyck4wWkUKLS0tIEMvalQvUDFPOGl2QndpUWlxUUkx
+            YzgrQ0h2NURUVlp2MXgwYVZETUZ0bkkK4KYnmGtSeaYzbsOcuzURj7axhlH9rrio
+            zSrfCuJGTzEpJ5p7CZz4QiVzSwC6/XfKAZTY8KnzbQjQwhRcpJxv/A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1cll0t2zmt8xj5x9zuka8zknymzqd5l4ewcv79yrwe9szd06kacyq5wfwr4
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBReTFrVkdrV1YrUTd3OERT
+            STFiTVdzd3RzQnV3MXBvaHgybTdiTHEvZ0NZCnhZNlFjV3VkNlpzZ2J0YkhETXVy
+            VXV2U202WGV6WlpkYzN3R3ZTL2ROWWMKLS0tIHJ2Y25iUmtNVGYvNUF6aVRmRlRD
+            T0NWWUFVVThaYVBEYmlJOGd1Tkd5ZWMKqdMChI9P2/VyAEBWXiwW+YxvYFfzlOq1
+            Ph6zJwpVPDJXRwzLSaC10T7BhL9n2bHttXG38J8cYNws7YHcH9cRHw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1g93uv85j5x5l9twvg4833736vcyrca2femh7gkytq8dtnhkzgs9qyfynf0
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWWVRBK1J2V2Q4aUdQVXFM
+            UTZkWlJRZ0ljbTVLZnY2MHJPTWxKc2Y3RDFNCkdBMDZKZFppc1B4OUlFYmxkNC9G
+            TE5nakQvWFViWXAyeVpQNllYR2M5Zk0KLS0tIFhXMEJGN3c2R3JJTVA0OEV1bG5i
+            UTk1M2hZQ0F6TEJYSFIwaWd1ZXo5T1EKOdGcFOBj/lVwmi91e15T3qRPrCsh6tif
+            i/4f3AQppOAFz8IgpkYbU8kiToMZHaRNhXh0CKCgsR7JIWis79Wwrg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age17mzyvmc2dr266c5ky90e8earmvy39awwskhk6nwfavn8vprq3gwqzhcc3e
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-31T21:22:22Z"
+    mac: ENC[AES256_GCM,data:3Eet7klgtDQZ0xbKtVQ78VfUTSVqup15dvVqoFchNRwMduH8lOMP38v/8J1vhHpIaLshr2HL1x1F9RhIXyVNHYmoGTVzdkb8VnthntgjB3UMpbGMLZF6V/auQm15449F0bFfNBWMzUoCwI3/2rUnQ2UN03/tpARhiszIryd6tF0=,iv:7jJ2GVPOBijibpljcXJ6rNYM6iRm8u6Ub/oMwICZfGk=,tag:DwIgqoFXtma807fDWys6Gw==,type:str]
+    version: 3.13.3

--- a/kubernetes/argocd/apps/workloads/paperless/manifests/pvc.yaml
+++ b/kubernetes/argocd/apps/workloads/paperless/manifests/pvc.yaml
@@ -1,0 +1,62 @@
+---
+# Documents + thumbnails. This is the irreplaceable data, so it lives on the
+# NAS where it gets picked up by the normal backup story.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-media
+  namespace: paperless
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: nas-nfs
+  resources:
+    requests:
+      storage: 200Gi
+---
+# Search index (tantivy, new in v3), classification model and logs. All of this
+# is rebuildable from the DB + media via `document_index reindex`, so losing it
+# is inconvenient rather than fatal. Kept on NFS anyway for schedulability —
+# the deployment is single-replica with strategy: Recreate so there is only
+# ever one writer against the index.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-data
+  namespace: paperless
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: nas-nfs
+  resources:
+    requests:
+      storage: 20Gi
+---
+# Drop folder. Exposed on the NAS so a scanner (or a Finder drag) can write
+# straight into it; paperless polls it (see PAPERLESS_CONSUMER_POLLING_INTERVAL).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-consume
+  namespace: paperless
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: nas-nfs
+  resources:
+    requests:
+      storage: 20Gi
+---
+# Target for `document_exporter` backups.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-export
+  namespace: paperless
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: nas-nfs
+  resources:
+    requests:
+      storage: 50Gi

--- a/kubernetes/argocd/apps/workloads/paperless/manifests/service.yaml
+++ b/kubernetes/argocd/apps/workloads/paperless/manifests/service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: paperless
+  namespace: paperless
+  labels:
+    app: paperless
+    component: server
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+  selector:
+    app: paperless
+    component: server

--- a/kubernetes/argocd/apps/workloads/paperless/manifests/tailscale-ingress.yaml
+++ b/kubernetes/argocd/apps/workloads/paperless/manifests/tailscale-ingress.yaml
@@ -1,0 +1,22 @@
+---
+# Private access on the Tailnet: https://paperless.border-enigmatic.ts.net/
+# Deliberately tailnet-only — this holds personal and financial documents.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: paperless-tailscale
+  namespace: paperless
+  labels:
+    app: paperless
+  annotations:
+    tailscale.com/hostname: "paperless"
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: paperless
+      port:
+        number: 80
+  tls:
+    - hosts:
+        - paperless


### PR DESCRIPTION
Adds [paperless-ngx](https://docs.paperless-ngx.com/) v3.0.4 as a document management server, reachable on the tailnet at https://paperless.border-enigmatic.ts.net.

## What's here

**Postgres** (`infrastructure/postgres`) — a `paperless` managed role and `Database` on the existing `postgres-homelab` CNPG cluster, following the same pattern as immich and tidewood. PG 16 is fine for paperless v3.

**Workload** (`workloads/paperless`) — namespace, PVCs, valkey broker, deployment, service, tailnet ingress.

## Notes on the choices

**Tailnet only.** No public ingress. This holds personal and financial documents.

**Storage split, all on `nas-nfs`:**

| PVC | Size | Holds |
|---|---|---|
| `paperless-media` | 200Gi | documents + thumbnails — the irreplaceable data |
| `paperless-data` | 20Gi | tantivy search index, classifier model |
| `paperless-consume` | 20Gi | drop folder |
| `paperless-export` | 50Gi | `document_exporter` target |

`PAPERLESS_EMPTY_TRASH_DIR` points at `media/trash`, so deletes are recoverable off the NAS rather than unlinked.

**Single writer.** `replicas: 1` with `strategy: Recreate`. The volumes are RWX, so a rolling update would briefly run two pods writing the same tantivy index.

**NFS consumption dir.** inotify is unreliable over NFS, so the consume dir is polled every 30s with a 10s stability delay to avoid grabbing a file the NAS is still flushing.

## v3-specific gotchas handled

v3.0.0 shipped 9 days ago. A fresh install avoids the migration breaking changes, but two config-level ones do apply:

- `PAPERLESS_SECRET_KEY` is now **required** — paperless refuses to start without it.
- `PAPERLESS_CONSUMER_POLLING` was replaced by `PAPERLESS_CONSUMER_POLLING_INTERVAL`. The old name is silently ignored, which would have meant a consume dir that never picks anything up.

Search moved from Whoosh to tantivy in v3; if indexing feels slow over NFS, moving `paperless-data` to `openebs-hostpath` is the fallback (the index is rebuildable via `document_index reindex`).

## Validation

- `task kubeconform` — all resources valid
- `task sops:check` — secrets encrypted
- `kubectl kustomize` builds clean for both dirs
- Image is multi-arch (amd64 + arm64), so it schedules on any node

🤖 Generated with [Claude Code](https://claude.com/claude-code)