### PR TITLE
fix(paperless): create the trash dir before startup

### DIFF
--- a/kubernetes/argocd/apps/workloads/paperless/manifests/deployment.yaml
+++ b/kubernetes/argocd/apps/workloads/paperless/manifests/deployment.yaml
@@ -27,6 +27,27 @@ spec:
       # No securityContext/runAsUser here on purpose. The upstream image uses
       # s6-overlay (ENTRYPOINT ["/init"]) and starts as root so it can map
       # ownership of the mounted volumes before dropping to uid 1000.
+      initContainers:
+        # PAPERLESS_EMPTY_TRASH_DIR has to exist before startup — paperless
+        # validates it in a Django system check and refuses to boot rather
+        # than creating it. Same image as the main container so this costs no
+        # extra pull, and uid 1000 is the user paperless drops to.
+        - name: init-trash-dir
+          image: ghcr.io/paperless-ngx/paperless-ngx:3.0.4
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /usr/src/paperless/media/trash
+              chown 1000:1000 /usr/src/paperless/media/trash
+          volumeMounts:
+            - name: media
+              mountPath: /usr/src/paperless/media
+          resources:
+            requests:
+              memory: 32Mi
+              cpu: 10m
       containers:
         - name: paperless
           image: ghcr.io/paperless-ngx/paperless-ngx:3.0.4


### PR DESCRIPTION
Paperless is crash-looping on first boot. `PAPERLESS_EMPTY_TRASH_DIR` has to already exist — paperless validates it in a Django system check and refuses to start rather than creating it:

```
[init-superuser] Creating superuser...
SystemCheckError: System check identified some issues:

ERRORS:
?: PAPERLESS_EMPTY_TRASH_DIR is set but doesn't exist.
	HINT: Create a directory at /usr/src/paperless/media/trash

s6-rc: warning: unable to start service init-system-checks: command exited 1
/run/s6/basedir/scripts/rc.init: fatal: stopping the container.
```

My miss in #845 — the docs do note the directory must exist beforehand, and I set the variable without creating it.

Adds an initContainer that `mkdir -p`s the path and chowns it to uid 1000 (the user paperless drops to after s6 finishes its root-owned setup). Reuses the paperless image, so it's already on the node and there's no extra pull or second tag for Renovate to track.

Everything before the check passed — migrations applied, Postgres and the valkey broker both connected — so this is the only thing standing between here and a running instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)