### PR TITLE
feat(paperless): consume from the NAS scans share [blocked on NAS setup]

### DIFF
--- a/kubernetes/argocd/apps/workloads/paperless/manifests/consume-storage.yaml
+++ b/kubernetes/argocd/apps/workloads/paperless/manifests/consume-storage.yaml
@@ -1,0 +1,46 @@
+---
+# The scanner inbox, shared between the Brother ADS-4700 and paperless.
+#
+# The Brother speaks SMB, not NFS, so the two meet on the NAS rather than in
+# the cluster: DSM exports /volume1/scans over SMB for the scanner and over
+# NFS for us. That is also why this is a static PV instead of a nas-nfs claim
+# — a dynamically provisioned directory is named after the PV's UUID, so it
+# would change out from under the scanner's profile any time the PVC was
+# recreated, and scans would pile up in an orphaned folder unnoticed.
+#
+# Requires a Synology shared folder named `scans` with both protocols enabled.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: paperless-scans
+  labels:
+    app: paperless
+spec:
+  capacity:
+    # Not enforced for NFS — this only has to match the claim below so the two
+    # bind. Actual space is whatever is free on volume1.
+    storage: 20Gi
+  accessModes:
+    - ReadWriteMany
+  # Retain: this directory belongs to the NAS, not to Kubernetes. Deleting the
+  # claim must never take a pending scan with it.
+  persistentVolumeReclaimPolicy: Retain
+  # Empty (not absent) so the default nas-nfs class doesn't claim this.
+  storageClassName: ""
+  nfs:
+    server: 192.168.1.2
+    path: /volume1/scans
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperless-scans
+  namespace: paperless
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: paperless-scans
+  resources:
+    requests:
+      storage: 20Gi

--- a/kubernetes/argocd/apps/workloads/paperless/manifests/deployment.yaml
+++ b/kubernetes/argocd/apps/workloads/paperless/manifests/deployment.yaml
@@ -173,7 +173,7 @@ spec:
             claimName: paperless-media
         - name: consume
           persistentVolumeClaim:
-            claimName: paperless-consume
+            claimName: paperless-scans
         - name: export
           persistentVolumeClaim:
             claimName: paperless-export

--- a/kubernetes/argocd/apps/workloads/paperless/manifests/kustomization.yaml
+++ b/kubernetes/argocd/apps/workloads/paperless/manifests/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - pvc.yaml
+  - consume-storage.yaml
   - broker.yaml
   - deployment.yaml
   - service.yaml

--- a/kubernetes/argocd/apps/workloads/paperless/manifests/pvc.yaml
+++ b/kubernetes/argocd/apps/workloads/paperless/manifests/pvc.yaml
@@ -32,21 +32,9 @@ spec:
     requests:
       storage: 20Gi
 ---
-# Drop folder. Exposed on the NAS so a scanner (or a Finder drag) can write
-# straight into it; paperless polls it (see PAPERLESS_CONSUMER_POLLING_INTERVAL).
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: paperless-consume
-  namespace: paperless
-spec:
-  accessModes:
-    - ReadWriteMany
-  storageClassName: nas-nfs
-  resources:
-    requests:
-      storage: 20Gi
----
+# The drop folder is not here — it is a static PV bound to an existing NAS
+# share so the scanner has a stable path. See consume-storage.yaml.
+#
 # Target for `document_exporter` backups.
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
> [!WARNING]
> **Do not merge until the Synology `scans` shared folder exists**, with NFS enabled for the cluster. Merging early leaves paperless unable to mount its consume volume. Merge #846 first.

Wires the Brother ADS-4700 into paperless.

## Why a static PV

The scanner speaks SMB and the cluster speaks NFS, so the two have to meet on the NAS. That part is unavoidable — but it does rule out a normal `nas-nfs` claim, because the provisioner names the directory after the PV's UUID:

```
/volume1/kubernetes-pvs/paperless-paperless-consume-pvc-99ef4b00-1294-4f0e-af13-2dd33cfd48d4
```

You can point an SMB share at that. It works right up until the PVC is recreated — cluster rebuild, prune, resize — at which point the directory is renamed and the scanner goes on writing into an orphan. Nothing errors; scans just stop arriving. A static PV on a stable path removes the failure mode.

`persistentVolumeReclaimPolicy: Retain` because the directory belongs to the NAS. Deleting the claim shouldn't take a pending scan with it.

## Changes

- New `consume-storage.yaml`: static PV + PVC named `paperless-scans`, bound to `192.168.1.2:/volume1/scans`
- Drop the dynamic `paperless-consume` PVC from `pvc.yaml`
- Deployment's consume volume now claims `paperless-scans`

Renaming rather than mutating the claim is deliberate: `storageClassName` and `volumeName` are immutable, so editing the existing PVC in place would wedge ArgoCD on a failed apply. With a new name it creates the pair, rolls the deployment, and prunes the old claim on its own — no manual `kubectl delete`.

## NAS prerequisites

Shared folder `scans` on volume1:
- **SMB** — a dedicated scan user with read/write. DSM defaults to min SMB2, which the ADS-4700 handles.
- **NFS** — rule for the cluster subnet, `rw`, **Allow users to access mounted subfolders** on, squash set so the scanner-written files stay deletable by uid 1000. Paperless removes each file after consuming it; if it can't, the same document gets ingested over and over.

## Validation

`task kubeconform` passes, `kubectl kustomize` builds clean. Untested against the live mount until the share exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)