### PR TITLE
fix(paperless): disable service link env injection

### DIFF
--- a/kubernetes/argocd/apps/workloads/paperless/manifests/deployment.yaml
+++ b/kubernetes/argocd/apps/workloads/paperless/manifests/deployment.yaml
@@ -24,6 +24,20 @@ spec:
         app: paperless
         component: server
     spec:
+      # Kubernetes injects <SERVICE>_PORT and friends into every pod for each
+      # service in the namespace. The service here is named `paperless`, so it
+      # injects PAPERLESS_PORT=tcp://10.96.x.x:80 — and PAPERLESS_PORT is also
+      # a real paperless setting (the port to listen on), so it wins over the
+      # image default and granian dies with:
+      #
+      #   Error: Invalid value for '--port': 'tcp://10.96.3.208:80'
+      #                                       is not a valid integer.
+      #
+      # Nothing here needs the injected vars — the broker is reached by DNS —
+      # so switch the whole mechanism off rather than papering over the one
+      # collision. Prevents the next PAPERLESS_*-shaped service name from
+      # doing this again.
+      enableServiceLinks: false
       # No securityContext/runAsUser here on purpose. The upstream image uses
       # s6-overlay (ENTRYPOINT ["/init"]) and starts as root so it can map
       # ownership of the mounted volumes before dropping to uid 1000.


### PR DESCRIPTION
Paperless still won't start after #846. Different cause:

```
Usage: granian [OPTIONS] APP
Error: Invalid value for '--port': 'tcp://10.96.3.208:80' is not a valid integer.
```

Kubernetes injects `<SERVICE>_PORT`, `<SERVICE>_SERVICE_HOST` etc. into every pod, one set per service in the namespace. Our service is named `paperless`, so every pod in the namespace gets:

```
PAPERLESS_PORT=tcp://10.96.3.208:80
```

`PAPERLESS_PORT` is [also a paperless setting](https://docs.paperless-ngx.com/configuration/#PAPERLESS_PORT) — the port to listen on. The injected value outranks the image's default, so v3's granian gets handed a URL where it wants an integer.

Nothing gets logged about the collision because from paperless's side it looks like a deliberately configured port.

## Fix

`enableServiceLinks: false` on the pod spec. Pinning `PAPERLESS_PORT: "8000"` in `env` would also work, but this kills the whole class — `paperless-broker` already injects `PAPERLESS_BROKER_*`, and the next service named along those lines gets to rediscover this. Nothing in the pod reads the injected vars; the broker is addressed by DNS at `redis://paperless-broker:6379`.

Worth knowing for anything else added to this namespace: a service name that maps onto a `PAPERLESS_*` setting will silently override it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)